### PR TITLE
税込表示にする

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,4 +5,10 @@ class Item < ApplicationRecord
   validates :description, length: { maximum: 200 }
 
   scope :default_order, -> { order(created_at: :desc) }
+
+  TAX = 1.10
+
+  def price_with_tax
+    (price * TAX)
+  end
 end

--- a/app/views/admins/items/index.html.haml
+++ b/app/views/admins/items/index.html.haml
@@ -16,7 +16,7 @@
         %td
           = item.name
         %td
-          = item.price
+          = number_to_currency(item.price_with_tax, unit: "¥", precision: 0)
         %td
           = item.description
         %td

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -8,4 +8,5 @@
           .card-body
             %h3.h5.card-title= item.name
             .card-text
-              = item.price
+              = number_to_currency(item.price_with_tax, unit: "¥", precision: 0)
+

--- a/spec/system/admins/items_spec.rb
+++ b/spec/system/admins/items_spec.rb
@@ -20,20 +20,20 @@ RSpec.describe '商品管理機能', type: :system do
     it '商品の一覧が閲覧できる' do
       visit admins_root_path
       expect(page).to have_content '大根'
-      expect(page).to have_content '200'
+      expect(page).to have_content '¥200'
     end
 
     it '商品を登録できる' do
       visit new_admins_item_path
       fill_in '商品名', with: 'にんじん'
-      fill_in '価格', with: '500'
+      fill_in '価格', with: '¥500'
       fill_in '説明', with: '美味しいにんじんを作ったので食べてください'
       expect do
         click_on '登録'
         expect(page).to have_content '商品の登録が完了しました'
       end.to change(Item, :count).by(1)
       expect(page).to have_content 'にんじん'
-      expect(page).to have_content '500'
+      expect(page).to have_content '¥500'
       expect(page).to have_content '美味しいにんじんを作ったので食べてください'
     end
 
@@ -41,7 +41,7 @@ RSpec.describe '商品管理機能', type: :system do
       visit admins_root_path
       click_on '編集'
       fill_in '商品名', with: 'きのこ'
-      fill_in '価格', with: '350'
+      fill_in '価格', with: '¥350'
       fill_in '説明', with: 'このきのこはすごく美味しいです'
       click_on '登録'
       expect(page).not_to have_content '大根'

--- a/spec/system/admins/items_spec.rb
+++ b/spec/system/admins/items_spec.rb
@@ -20,20 +20,20 @@ RSpec.describe '商品管理機能', type: :system do
     it '商品の一覧が閲覧できる' do
       visit admins_root_path
       expect(page).to have_content '大根'
-      expect(page).to have_content '¥200'
+      expect(page).to have_content '¥220'
     end
 
     it '商品を登録できる' do
       visit new_admins_item_path
       fill_in '商品名', with: 'にんじん'
-      fill_in '価格', with: '¥500'
+      fill_in '価格', with: '500'
       fill_in '説明', with: '美味しいにんじんを作ったので食べてください'
       expect do
         click_on '登録'
         expect(page).to have_content '商品の登録が完了しました'
       end.to change(Item, :count).by(1)
       expect(page).to have_content 'にんじん'
-      expect(page).to have_content '¥500'
+      expect(page).to have_content '¥550'
       expect(page).to have_content '美味しいにんじんを作ったので食べてください'
     end
 
@@ -41,7 +41,7 @@ RSpec.describe '商品管理機能', type: :system do
       visit admins_root_path
       click_on '編集'
       fill_in '商品名', with: 'きのこ'
-      fill_in '価格', with: '¥350'
+      fill_in '価格', with: '350'
       fill_in '説明', with: 'このきのこはすごく美味しいです'
       click_on '登録'
       expect(page).not_to have_content '大根'

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe '商品管理機能', type: :system do
   context 'ログインしてない時' do
-    let!(:item) { create(:item, name: '大根', price: '¥200') }
+    let!(:item) { create(:item, name: '大根', price: '200') }
 
     it '商品の一覧ページを閲覧できること' do
       visit root_path
       expect(page).to have_content '大根'
-      expect(page).to have_content '¥200'
+      expect(page).to have_content '¥220'
     end
   end
 end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe '商品管理機能', type: :system do
   context 'ログインしてない時' do
-    let!(:item) { create(:item, name: '大根', price: '200') }
+    let!(:item) { create(:item, name: '大根', price: '¥200') }
 
     it '商品の一覧ページを閲覧できること' do
       visit root_path
       expect(page).to have_content '大根'
-      expect(page).to have_content '200'
+      expect(page).to have_content '¥200'
     end
   end
 end


### PR DESCRIPTION
### やったこと
- 税込表示にする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to calculate item prices inclusive of tax.
- **Improvements**
	- Updated item price displays in both admin and user interfaces to show prices formatted in Japanese Yen (¥).
- **Bug Fixes**
	- Adjusted test cases to reflect the new currency format for item prices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->